### PR TITLE
修复BIG O章节里的示例代码

### DIFF
--- a/VI.Big_O.md
+++ b/VI.Big_O.md
@@ -138,7 +138,7 @@ Big O、big omega 和 big theta 描述了运行时的上限，下限和严格范
 1 	int min = Integer.MAX_VALUE; 
 2 	int max = Integer.MIN_VALUE; 
 3 	for (int x ： array) {
-4 		if (x < min) min x; 
+4 		if (x < min) min = x; 
 5 		if (x > max) max = x;
 6 	}
 ```


### PR DESCRIPTION
修复“BIG O章节”里的示例代码 “Min and Max 1” 中缺失一个赋值号。
